### PR TITLE
Fix sun positioning: inverted day/night and straight terminator

### DIFF
--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -51,7 +51,7 @@ function clampDeclination(declRaw) {
  *   A*sin(phi) + B*cos(phi) = s
  * where A = sin(decl), B = cos(decl)*cos(H), s = sin(altThreshold).
  *
- * The (+) root always yields the night-side boundary for thresholds >= -6 deg,
+ * The (-) root always yields the night-side boundary for thresholds >= -6 deg,
  * which have polar-cap topology. Deeper thresholds (< -12 deg) form a band near
  * the anti-solar side and are not handled here (V1 scope: 0 deg and -6 deg only).
  *
@@ -75,7 +75,7 @@ function buildNightPolygon(ssLon, declRaw, altThresholdDeg) {
     if (Math.abs(denom) < 1e-8) {
       t = -(B - s) / (2 * A);
     } else {
-      t = (A + Math.sqrt(disc)) / denom;
+      t = (A - Math.sqrt(disc)) / denom;
     }
 
     let lat = 2 * Math.atan(t) * DEG;


### PR DESCRIPTION
## Summary

- Fixes the day/night overlay being inverted (dark where it should be light and vice versa)
- Fixes the terminator appearing as a straight vertical line instead of a sinusoidal curve

## Root cause

`buildNightPolygon` uses a Weierstrass half-angle substitution to solve for the latitude of the terminator at each longitude. The quadratic has two roots: the `(-)` root traces the **night-side** boundary, the `(+)` root traces the **day-side** boundary. The code was using `(+)`, so the polygon covered the day region instead of the night region.

The wrong root also produces a near-vertical discontinuity at the longitudes ±90° away from the subsolar point (where `cos(H) → 0` and the denominator flips sign), rather than the correct smooth sinusoidal terminator curve.

## Fix

One character: `+` → `-` in the quadratic root selection.

## Test plan

- [ ] Verify dark region is centered on the hemisphere opposite the subsolar point
- [ ] Verify the terminator is a smooth curve, highest latitude on the anti-solar meridian, lowest on the solar meridian
- [ ] Check at multiple times of day and seasons (different declinations)
- [ ] Verify twilight band (−6°) also renders correctly inside the night polygon

https://claude.ai/code/session_01JqYE3qrFXg4Zns3swCjbdy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqYE3qrFXg4Zns3swCjbdy)_